### PR TITLE
shelter: use udhcpc as dhcp client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ _depend_redhat: # Install the build and runtime dependencies on redhat-like syst
 	    libcap-ng-devel automake libtool \
 	    diffutils rsync sed systemd socat +podman-docker \
 	    +busybox kmod bubblewrap qemu-kvm zstd glib2-devel \
-	    tar openssl dhcp-client \
+	    tar openssl \
 		gcc make autoconf \
 		automake gettext-devel pkgconfig \
 		openssl-devel popt-devel device-mapper-devel \
@@ -129,7 +129,7 @@ _depend_debian: # Install the build and runtime dependencies on debian-like syst
 	    libseccomp-dev libcap-ng-dev \
 	    diffutils rsync libc-bin sed systemd socat \
 	    busybox-static kmod bubblewrap qemu-system-x86 zstd \
-	    tar openssl isc-dhcp-client
+	    tar openssl
 
 	@sudo pip install toml-cli --proxy=$(HTTPS_PROXY)
 
@@ -197,6 +197,7 @@ install: # Install the build artifacts
 	            sudo install -m 0755 "images/conf/power" "$${dest}/conf"; \
 	            sudo install -m 0644 "images/conf/acpid.conf" "$${dest}/conf"; \
 	            sudo install -m 0644 "images/conf/blacklist.conf" "$${dest}/conf"; \
+	            sudo install -m 0755 "images/conf/default.script" "$${dest}/conf"; \
 	        }; \
 	        cd images/$${d}; \
 	        sudo install -m 0644 "mkosi.conf" "$${dest}"; \

--- a/images/conf/default.script
+++ b/images/conf/default.script
@@ -1,0 +1,177 @@
+#!/bin/sh
+
+# script for udhcpc
+# Copyright (c) 2008 Natanael Copa <natanael.copa@gmail.com>
+
+UDHCPC="/etc/udhcpc"
+UDHCPC_CONF="$UDHCPC/udhcpc.conf"
+
+RESOLV_CONF="/etc/resolv.conf"
+[ -f $UDHCPC_CONF ] && . $UDHCPC_CONF
+
+export broadcast
+export dns
+export domain
+export interface
+export ip
+export mask
+export metric
+export staticroutes
+export router
+export subnet
+
+export PATH=/usr/bin:/bin:/usr/sbin:/sbin
+
+run_scripts() {
+	local dir=$1
+	if [ -d $dir ]; then
+		for i in $dir/*; do
+			[ -f $i ] && $i
+		done
+	fi
+}
+
+deconfig() {
+	ip -4 addr flush dev $interface
+}
+
+is_wifi() {
+	test -e /sys/class/net/$interface/phy80211
+}
+
+if_index() {
+	if [ -e  /sys/class/net/$interface/ifindex ]; then
+		cat /sys/class/net/$interface/ifindex
+	else
+		ip -4 link show dev $interface | head -n1 | cut -d: -f1
+	fi
+}
+
+calc_metric() {
+	local base=
+	if is_wifi; then
+		base=300
+	else
+		base=200
+	fi
+	echo $(( $base + $(if_index) ))
+}
+
+route_add() {
+	local to=$1 gw=$2 num=$3
+	# special case for /32 subnets:
+	# /32 instructs kernel to always use routing for all outgoing packets
+	# (they can never be sent to local subnet - there is no local subnet for /32).
+	# Used in datacenters, avoids the need for private ip-addresses between two hops.
+	if [ "$subnet" = "255.255.255.255" ]; then
+		ip -4 route add $gw dev $interface
+	fi
+	ip -4 route add $to via $gw dev $interface \
+		metric $(( $num + ${IF_METRIC:-$(calc_metric)} ))
+}
+
+routes() {
+	[ -z "$router" ] && [ -z "$staticroutes" ] && return
+	for i in $NO_GATEWAY; do
+		[ "$i" = "$interface" ] && return
+	done
+	while ip -4 route del default via dev $interface 2>/dev/null; do
+		:
+	done
+	local num=0
+	# RFC3442:
+	# If the DHCP server returns both a Classless Static Routes option
+	# and a Router option, the DHCP client MUST ignore the Router option.
+	if [ -n "$staticroutes" ]; then
+		# static routes format: dest1/mask gw1 ... destn/mask gwn
+		set -- $staticroutes
+		while [ -n "$1" ] && [ -n "$2" ]; do
+			local dest="$1" gw="$2"
+			if [ "$gw" != "0.0.0.0" ]; then
+				route_add $dest $gw $num && num=$(( $num + 1))
+			fi
+			shift 2
+		done
+	else
+		local gw=
+		for gw in $router; do
+			route_add 0.0.0.0/0 $gw $num && num=$(( $num + 1 ))
+		done
+	fi
+}
+
+resolvconf() {
+	local i
+	[ -n "$IF_PEER_DNS" ] && [ "$IF_PEER_DNS" != "yes" ] && return
+	if [ "$RESOLV_CONF" = "no" ] || [ "$RESOLV_CONF" = "NO" ] \
+			|| [ -z "$RESOLV_CONF" ] || [ -z "$dns" ]; then
+		return
+	fi
+	for i in $NO_DNS; do
+		[ "$i" = "$interface" ] && return
+	done
+	echo -n > "$RESOLV_CONF.$$"
+	if [ -n "$search" ]; then
+		echo "search $search" >> "$RESOLV_CONF.$$"
+	elif [ -n "$domain" ]; then
+		echo "search $domain" >> "$RESOLV_CONF.$$"
+	fi
+	for i in $dns; do
+		echo "nameserver $i" >> "$RESOLV_CONF.$$"
+	done
+	chmod a+r "$RESOLV_CONF.$$"
+	mv -f "$RESOLV_CONF.$$" "$RESOLV_CONF"
+}
+
+bound() {
+	ip -4 addr add $ip/$mask ${broadcast:+broadcast $broadcast} dev $interface
+	ip -4 link set dev $interface up
+	routes
+	resolvconf
+}
+
+renew() {
+	if ! ip -4 addr show dev $interface | grep $ip/$mask; then
+		ip -4 addr flush dev $interface
+		ip -4 addr add $ip/$mask ${broadcast:+broadcast $broadcast} dev $interface
+	fi
+
+	local i
+	for i in $router; do
+		if ! ip -4 route show | grep ^default | grep $i; then
+			routes
+			break
+		fi
+	done
+
+	if ! grep "^search $domain"; then
+		resolvconf
+		return
+	fi
+	for i in $dns; do
+		if ! grep "^nameserver $i"; then
+			resolvconf
+			return
+		fi
+	done
+}
+
+case "$1" in
+	deconfig|renew|bound)
+		run_scripts $UDHCPC/pre-$1
+		$1
+		run_scripts $UDHCPC/post-$1
+		;;
+	leasefail)
+		echo "udhcpc failed to get a DHCP lease" >&2
+		;;
+	nak)
+		echo "udhcpc received DHCP NAK" >&2
+		;;
+	*)
+		echo "Error: this script should be called from udhcpc" >&2
+		exit 1
+		;;
+esac
+exit 0
+

--- a/images/disk/mkosi.build
+++ b/images/disk/mkosi.build
@@ -25,8 +25,10 @@ mkdir -p $DESTDIR/etc/init.d
 mkdir -p $DESTDIR/etc/acpi
 mkdir -p $DESTDIR/etc/modprobe.d
 mkdir -p $DESTDIR/usr/bin/
+mkdir -p $DESTDIR/usr/share/udhcpc
 
 cp rcS $DESTDIR/etc/init.d/
 cp ./conf/acpid.conf $DESTDIR/etc/
 cp ./conf/power $DESTDIR/etc/acpi/
 cp ./conf/blacklist.conf $DESTDIR/etc/modprobe.d/
+cp ./conf/default.script  $DESTDIR/usr/share/udhcpc/

--- a/images/disk/rcS
+++ b/images/disk/rcS
@@ -10,9 +10,8 @@ acpid
 socat -t 3600 vsock-listen:4321,reuseaddr,fork "exec:'xargs --no-run-if-empty -0 sh -c',stderr" &
 
 # try to config network
-if [ -x /usr/sbin/dhclient ];then
-    /usr/sbin/dhclient
-fi
+iplink set eth0 up
+udhcpc -b
 
 # start the other service
 for script in $(find /etc/init.d -maxdepth 1 -type f -perm /111 ! -name rcS); do

--- a/images/initrd/mkosi.build
+++ b/images/initrd/mkosi.build
@@ -25,8 +25,10 @@ mkdir -p $DESTDIR/etc/init.d
 mkdir -p $DESTDIR/etc/acpi
 mkdir -p $DESTDIR/etc/modprobe.d
 mkdir -p $DESTDIR/usr/bin/
+mkdir -p $DESTDIR/usr/share/udhcpc
 
 cp rcS $DESTDIR/etc/init.d/
 cp ./conf/acpid.conf $DESTDIR/etc/
 cp ./conf/power $DESTDIR/etc/acpi/
 cp ./conf/blacklist.conf $DESTDIR/etc/modprobe.d/
+cp ./conf/default.script  $DESTDIR/usr/share/udhcpc/

--- a/images/initrd/rcS
+++ b/images/initrd/rcS
@@ -28,9 +28,8 @@ acpid
 socat -t 3600 vsock-listen:4321,reuseaddr,fork "exec:'xargs --no-run-if-empty -0 sh -c',stderr" &
 
 # try to config network
-if [ -x /usr/sbin/dhclient ];then
-    /usr/sbin/dhclient
-fi
+iplink set eth0 up
+udhcpc -b
 
 # start the other service
 for script in $(find /etc/init.d -maxdepth 1 -type f -perm /111 ! -name rcS); do

--- a/shelter
+++ b/shelter
@@ -28,7 +28,7 @@ CONF="${SHELTER_IMAGE_DIR}/build.conf"
 
 SHELTER_CLEAN_FLAG="false"
 
-ESSENTIAL_BINARIES=("socat" "busybox" "kmod" "cryptsetup" "dhclient" "dhclient-script")
+ESSENTIAL_BINARIES=("socat" "busybox" "kmod" "cryptsetup")
 ESSENTIAL_FILES=()
 
 # Timeout for rcS getting started to listen vsock


### PR DESCRIPTION
换用busybox的udhcpc作为shelter镜像的dhcp client

udhcpc的配置脚本（default.script）来自alpinelinux

[default.script 源地址](https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/main/busybox/default.script)

[udhcpc alpinelinux wiki地址](https://wiki.alpinelinux.org/wiki/Udhcpc)