### PR TITLE
add the essential binary kbs and fix make test when image type is disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,8 @@ test: # Run verify-signature demo with shelter
 
 	@echo -e "\033[1;31mRunning the DEMO verify-signature in shelter guest ...\033[0m"
 	@./shelter build -t shelter-demos -c ./demos/verify-signature/build.conf && \
+	  { [ "$$(toml get --toml-path /var/lib/shelter/images/shelter-demos/image_info.toml image_type)" = "disk" ] && \
+		./demos/verify-signature/kbs.sh || true; } && \
 	  ./shelter run shelter-demos verifier.sh \
 	    /keys/public_key.pem \
 	    /payload/archive.tar.gz.sig \
@@ -328,6 +330,9 @@ test: # Run verify-signature demo with shelter
 	@echo -e "\033[1;31mRunning the DEMO mount in shelter guest ...\033[0m"
 	@./shelter run shelter-demos -v demos:/root/demos -v libexec:/root/libexec \
 	  ls -l /root/demos /root/libexec
+
+	@[ "$$(toml get --toml-path /var/lib/shelter/images/shelter-demos/image_info.toml image_type)" = "disk" ] && \
+		./demos/verify-signature/kbs.sh || true
 
 all: # Equivalent to make prepare build install
 	@make prepare build install

--- a/demos/verify-signature/kbs.sh
+++ b/demos/verify-signature/kbs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+## stop kbs if it is active and return immediately
+systemctl --user -q is-active kbs.service && \
+systemctl --user stop kbs && \
+echo "stop kbs service" && \
+exit 0
+
+## start kbs if it isn't active
+if [ -d "/tmp/kbs" ]; then
+    rm -r /tmp/kbs
+fi
+
+mkdir /tmp/kbs
+mkdir /tmp/kbs/{repository,attestation-service}
+cp demos/verify-signature/kbs/* /tmp/kbs/
+
+openssl genpkey -algorithm ed25519 > /tmp/kbs/private.key
+openssl pkey -in /tmp/kbs/private.key -pubout -out /tmp/kbs/public.pub
+
+systemd-run --user --description=Shelter --unit="kbs" -G /usr/local/libexec/shelter/kbs -c /tmp/kbs/config.toml && \
+echo "start kbs"
+
+sleep 5
+
+/usr/local/libexec/shelter/kbs-client \
+config --auth-private-key /tmp/kbs/private.key \
+set-resource --resource-file /var/lib/shelter/images/shelter-demos/passphrase \
+--path default/shelter-demos/passphrase && \
+echo "upload passphrase"

--- a/demos/verify-signature/kbs/allow_all.rego
+++ b/demos/verify-signature/kbs/allow_all.rego
@@ -1,0 +1,4 @@
+
+package policy
+
+default allow = true

--- a/demos/verify-signature/kbs/config.toml
+++ b/demos/verify-signature/kbs/config.toml
@@ -1,0 +1,26 @@
+insecure_http = true
+insecure_api = true
+sockets = ["0.0.0.0:8080"]
+auth_public_key = "/tmp/kbs/public.pub"
+
+[attestation_token_config]
+attestation_token_type = "CoCo"
+
+[repository_config]
+type = "LocalFs"
+dir_path = "/tmp/kbs/repository"
+
+[as_config]
+work_dir = "/tmp/kbs/attestation-service"
+policy_engine = "opa"
+attestation_token_broker = "Simple"
+
+[as_config.attestation_token_config]
+duration_min = 5
+
+[as_config.rvps_config]
+store_type = "LocalFs"
+remote_addr = ""
+
+[policy_engine_config]
+policy_path = "/tmp/kbs/allow_all.rego"

--- a/images/disk/init
+++ b/images/disk/init
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-PATH=$PATH:/usr/local/bin
+PATH=$PATH:/usr/local/bin:/usr/local/libexec/shelter
 
 BUSYBOX="/usr/bin/busybox"
 [ ! -x "$BUSYBOX" ] && BUSYBOX="/usr/sbin/busybox"

--- a/patches/trustee/trustee-kbs-verifier.patch
+++ b/patches/trustee/trustee-kbs-verifier.patch
@@ -1,0 +1,13 @@
+diff --git a/attestation-service/Cargo.toml b/attestation-service/Cargo.toml
+index 529fa6e..05d2303 100644
+--- a/attestation-service/Cargo.toml
++++ b/attestation-service/Cargo.toml
+@@ -66,7 +66,7 @@ tonic = { workspace = true, optional = true }
+ uuid = { version = "1.1.2", features = ["v4"] }
+ 
+ [target.'cfg(not(target_arch = "s390x"))'.dependencies]
+-verifier = { path = "../deps/verifier", default-features = false, features = ["all-verifier"] }
++verifier = { path = "../deps/verifier", default-features = false, features = ["snp-verifier", "csv-verifier"] }
+ 
+ [target.'cfg(target_arch = "s390x")'.dependencies]
+ verifier = { path = "../deps/verifier", default-features = false, features = ["se-verifier"] }


### PR DESCRIPTION
Remember：when image type is disk，we need to add two kernel parameters. 

An example `shelter.conf`:
~~~
image_type = "disk"
vmm = "qemu"

[qemu]
bin = "/usr/libexec/qemu-kvm"
mem = "4G"
cpus = "2"
firmware =""
kern_cmdline = "KBS_URL=http://192.168.10.51:8080 PASSPHRASE_PATH=default/shelter-demos/passphrase"
opts = ""
~~~

Make test success output as shown below:
~~~
[2024-10-21 18:28:14][INFO] Using Image ID: shelter-demos
Running as unit: shelter_shelter-demos.service
Verified OK
Signature verified successfully.
~~~