### PR TITLE
Shelter: support initrd remote attestation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,8 +317,7 @@ test: # Run verify-signature demo with shelter
 
 	@echo -e "\033[1;31mRunning the DEMO verify-signature in shelter guest ...\033[0m"
 	@./shelter build -t shelter-demos -c ./demos/verify-signature/build.conf && \
-	  { [ "$$(toml get --toml-path /var/lib/shelter/images/shelter-demos/image_info.toml image_type)" = "disk" ] && \
-	    ./demos/verify-signature/kbs.sh || true; } && \
+	  ./demos/verify-signature/kbs.sh && \
 	  ./shelter run shelter-demos verifier.sh \
 	    /keys/public_key.pem \
 	    /payload/archive.tar.gz.sig \
@@ -331,8 +330,7 @@ test: # Run verify-signature demo with shelter
 	@./shelter run shelter-demos -v demos:/root/demos -v libexec:/root/libexec \
 	  ls -l /root/demos /root/libexec
 
-	@[ "$$(toml get --toml-path /var/lib/shelter/images/shelter-demos/image_info.toml image_type)" = "disk" ] && \
-	  ./demos/verify-signature/kbs.sh || true
+	@./demos/verify-signature/kbs.sh
 
 all: # Equivalent to make prepare build install
 	@make prepare build install

--- a/demos/verify-signature/kbs.sh
+++ b/demos/verify-signature/kbs.sh
@@ -18,13 +18,17 @@ cp demos/verify-signature/kbs/* /tmp/kbs/
 openssl genpkey -algorithm ed25519 > /tmp/kbs/private.key
 openssl pkey -in /tmp/kbs/private.key -pubout -out /tmp/kbs/public.pub
 
-systemd-run --user --description=Shelter --unit="kbs" -G /usr/local/libexec/shelter/kbs -c /tmp/kbs/config.toml && \
+systemd-run --user --description="kbs test server" --unit="kbs" -G /usr/local/libexec/shelter/kbs -c /tmp/kbs/config.toml && \
 echo "start kbs"
 
-sleep 5
 
-/usr/local/libexec/shelter/kbs-client \
-config --auth-private-key /tmp/kbs/private.key \
-set-resource --resource-file /var/lib/shelter/images/shelter-demos/passphrase \
---path default/shelter-demos/passphrase && \
-echo "upload passphrase"
+if [ "$(toml get --toml-path /var/lib/shelter/images/shelter-demos/image_info.toml image_type)" = "disk" ]; then
+    sleep 5
+
+    /usr/local/libexec/shelter/kbs-client \
+    config --auth-private-key /tmp/kbs/private.key \
+    set-resource --resource-file /var/lib/shelter/images/shelter-demos/passphrase \
+    --path default/shelter-demos/passphrase
+
+    echo "upload passphrase"
+fi

--- a/images/initrd/rcS
+++ b/images/initrd/rcS
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+PATH=$PATH:/usr/local/bin:/usr/local/libexec/shelter
+
 BUSYBOX="/usr/bin/busybox"
 [ ! -x "$BUSYBOX" ] && BUSYBOX="/usr/sbin/busybox"
 
@@ -25,11 +27,13 @@ find /sys/ -name modalias -print0 | \
 
 acpid
 
-socat -t 3600 vsock-listen:4321,reuseaddr,fork "exec:'xargs --no-run-if-empty -0 sh -c',stderr" &
-
 # try to config network
 iplink set eth0 up
 udhcpc -b
+
+kbs-client --url $KBS_URL attest || poweroff
+
+socat -t 3600 vsock-listen:4321,reuseaddr,fork "exec:'xargs --no-run-if-empty -0 sh -c',stderr" &
 
 # start the other service
 for script in $(find /etc/init.d -maxdepth 1 -type f -perm /111 ! -name rcS); do


### PR DESCRIPTION
Add remote attestation support for initrd

If kbs-client attests fail, the VM will shut down.

Remote attestation requires a kernel parameter

Like below:
~~~toml
image_type = "initrd"
vmm = "qemu"

[qemu]
bin = "/usr/libexec/qemu-kvm"
mem = "4G"
cpus = "2"
firmware =""
kern_cmdline = "KBS_URL=http://192.168.10.51:8080"
opts = ""

~~~